### PR TITLE
Check for tabs during test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,16 @@ var gulp = require('gulp');
 var jscs = require('gulp-jscs');
 var jshint = require('gulp-jshint');
 var nodeunit = require('gulp-nodeunit');
+var jsonlint = require('gulp-json-lint');
+var replace = require('gulp-replace');
+
+// We manually remove hard tabs from these files and make sure they are valid
+// JSON.
+var nonJSFiles = [
+  '.jscsrc',
+  '.jshintrc',
+  'package.json'
+];
 
 var sourceFiles = [
   'examples/**.js',
@@ -29,13 +39,27 @@ gulp.task('jshint', function() {
     .pipe(jshint.reporter('fail'));
 });
 
+// Make sure out package.json looks nice.
+gulp.task('jsonlint', function() {
+  return gulp.src(nonJSFiles)
+    .pipe(jsonlint())
+    .pipe(jsonlint.report('verbose'));
+});
+
+// Remove tabs from non-JS files (package.json and JSCS/JSHint configs).
+gulp.task('removetabs', function() {
+  return gulp.src(nonJSFiles)
+    .pipe(replace(/\t/g, '  '))
+    .pipe(gulp.dest('.'));
+});
+
 // Run Unit tests
 gulp.task('nodeunit', function() {
   return gulp.src('tests/unit/**/test.*.js')
     .pipe(nodeunit());
 });
 
-gulp.task('lint', ['jshint', 'jscs']);
-gulp.task('test', ['jshint', 'jscs', 'nodeunit']);
+gulp.task('lint', ['jshint', 'jscs', 'jsonlint', 'removetabs']);
+gulp.task('test', ['lint', 'nodeunit']);
 
 gulp.task('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "gulp": "^3.8.10",
     "gulp-jscs": "^1.3.1",
     "gulp-jshint": "^1.9.0",
+    "gulp-json-lint": "0.0.1",
     "gulp-nodeunit": "0.0.5",
+    "gulp-replace": "^0.5.0",
     "jshint-stylish": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
There is no way to have the linter complain about tabs but at least this automatically converts them when folks run the tests, so it *should* prevent **most** tabs from creeping in!